### PR TITLE
Fix server column name in token entity unique constraint

### DIFF
--- a/src/main/java/de/uoc/dh/idh/autodone/entities/TokenEntity.java
+++ b/src/main/java/de/uoc/dh/idh/autodone/entities/TokenEntity.java
@@ -23,7 +23,7 @@ import lombok.Data;
 @Data()
 @Entity()
 @JsonNaming(SnakeCaseStrategy.class)
-@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "server", "username" }) })
+@Table(uniqueConstraints = { @UniqueConstraint(columnNames = { "server_uuid", "username" }) })
 public class TokenEntity {
 
 	@Id()


### PR DESCRIPTION
The generated name of the server column is `server_uuid`, not `server`.